### PR TITLE
IT-1221: No wget on Ubuntu?

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -14,6 +14,8 @@ jobs:
     needs: pre-commit
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Install wget
+        run: sudo apt-get install wget
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Assume AWS role


### PR DESCRIPTION
Deploy failed with '/bin/sh: 1: wget: not found' and then 'subprocess.CalledProcessError: Command 'wget https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.2.5/templates/VPC/vpc-mini.yaml -N -P templates/remote' returned non-zero exit status 127.'. 